### PR TITLE
Fix/audio compare local model path + Save checkpoints by steps

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -1220,7 +1220,7 @@ class Qwen3FineTune:
 
                 # Calculate total steps and global step counter
                 total_steps_per_epoch = len(train_dataloader)
-                total_steps = total_steps_per_epoch * epochs
+                total_steps = total_steps_per_epoch * end_epoch
                 global_step = start_epoch * total_steps_per_epoch  # Resume from correct step
 
                 for epoch in range(start_epoch, end_epoch):


### PR DESCRIPTION
- This fixes #21 adding a local model path to the node, if not provided will use the defaults model path.
- Replaced the checkpoint save/delete options (keep_intermediate_checkpoints) for a save every X epoch/step. (independent). 

- The node still saves at the final epoch always.

- The output is now in steps (instead of only epochs) as this model does not need need much to be finetune, so the user have more precision this way. (console and ui visualization on the node).
- Added Lr to the output (qwen uses a fix lr, so is not going to change until it starts to go down due to convergence) - to help monitoring the finetune process.
